### PR TITLE
Constants refactor: public/private constants, replace define (typeless) by real typed constants

### DIFF
--- a/ios/Source/Core/LRSession.h
+++ b/ios/Source/Core/LRSession.h
@@ -14,8 +14,6 @@
 
 #import "LRCallback.h"
 
-#define DEFAULT_CONNECTION_TIMEOUT 15
-
 /**
  * @author Bruno Farache
  */

--- a/ios/Source/Core/LRSession.m
+++ b/ios/Source/Core/LRSession.m
@@ -15,6 +15,8 @@
 #import "LRHttpUtil.h"
 #import "LRSession.h"
 
+static const int DEFAULT_CONNECTION_TIMEOUT = 15;
+
 /**
  * @author Bruno Farache
  */

--- a/ios/Source/Http/LRHttpUtil.h
+++ b/ios/Source/Http/LRHttpUtil.h
@@ -14,19 +14,10 @@
 
 #import "LRBatchSession.h"
 
-#define GET @"GET"
-#define HEAD @"HEAD"
-#define POST @"POST"
+extern const int V_UNKNOWN;
+extern const int V_6_2;
 
-#define UNKNOWN -1
-#define V_6_2 6200
-
-#define ERROR_DOMAIN @"com.liferay.mobile.sync.ErrorDomain"
-#define IF_MODIFIED_SINCE @"If-Modified-Since"
-#define LAST_MODIFIED @"Last-Modified"
-#define SERVER_EXCEPTION 1
-#define STATUS_OK 200
-#define STATUS_UNAUTHORIZED 401
+extern NSString *const ERROR_DOMAIN;
 
 /**
  * @author Bruno Farache

--- a/ios/Source/Http/LRHttpUtil.m
+++ b/ios/Source/Http/LRHttpUtil.m
@@ -14,6 +14,21 @@
 
 #import "LRHttpUtil.h"
 
+const int V_UNKNOWN = -1;
+const int V_6_2 = 6200;
+
+NSString *const ERROR_DOMAIN = @"com.liferay.mobile.sync.ErrorDomain";
+
+static NSString *const GET = @"GET";
+static NSString *const HEAD = @"HEAD";
+static NSString *const POST = @"POST";
+
+static NSString *const IF_MODIFIED_SINCE = @"If-Modified-Since";
+static NSString *const LAST_MODIFIED = @"Last-Modified";
+
+static const int STATUS_OK = 200;
+static const int STATUS_UNAUTHORIZED = 401;
+
 /**
  * @author Bruno Farache
  */
@@ -49,14 +64,14 @@ static NSMutableDictionary *_versions;
 		error:error];
 
 	if (*error) {
-		return UNKNOWN;
+		return V_UNKNOWN;
 	}
 
 	NSDictionary *headers = [response allHeaderFields];
 	NSString *portalHeader = [headers objectForKey:@"Liferay-Portal"];
 
 	if (!portalHeader) {
-		version = @(UNKNOWN);
+		version = @(V_UNKNOWN);
 
 		[_versions setObject:version forKey:URL];
 
@@ -71,7 +86,7 @@ static NSMutableDictionary *_versions;
 			range:searchRange];
 
 	if (buildRange.location == NSNotFound) {
-		version = @(UNKNOWN);
+		version = @(V_UNKNOWN);
 	}
 	else {
 		int indexOfBuild = buildRange.location + buildRange.length;


### PR DESCRIPTION
This is a proposal of new use of constants. Just for your consideration.
Names maybe should be also changed because we're polluting the namespace (GET for a constant name is such generic name that could conflict other project specific symbols)
